### PR TITLE
Future proofing

### DIFF
--- a/emiproc/exports/icon.py
+++ b/emiproc/exports/icon.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from datetime import datetime, timedelta
 from enum import Enum, auto
 import logging

--- a/emiproc/profiles/operators.py
+++ b/emiproc/profiles/operators.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import numpy as np
 import xarray as xr
 import geopandas as gpd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "rasterio",
     "pyogrio",
     "pygeos",
+    "pyyaml",
 ]
 license = {file = "LICENSE.txt"}
 readme = "README.md"


### PR DESCRIPTION
Adding the `from __future__ import annotations` feature to the code, needed for Python versions < 3.10.