### PR TITLE
fix vprm parameters

### DIFF
--- a/emiproc/profiles/vprm.py
+++ b/emiproc/profiles/vprm.py
@@ -273,12 +273,21 @@ def calculate_vprm_emissions(df: pd.DataFrame, df_vprm: pd.DataFrame) -> pd.Data
         Wscale  = (1 + lswi) / (1 + np.nanmax(lswi))
         df[(vegetation_type, 'Wscale')] = Wscale
 
+        evithr = np.nanmin(evi) + 0.55 * (np.nanmax(evi) - np.nanmin(evi))                                                                                                                                                                                    
+
         if is_urban:
             # Simpler EVI forumalation in urban VPRM
             Pscale  = (evi - np.nanmin(evi)) / (np.nanmax(evi) - np.nanmin(evi))
         else:
-            Pscale  = (1 + lswi) / 2.0
+           Pscale  = (1 + lswi) / 2.0 ## bad-burst to full canopy period
+           Pscale[evi >= evithr] = 1 ## full leaf expansion / full canopy period
+
+        # for evergreen, Pscale is 1 fixed (Mahadevan et al, paragraph [13])
+        if vegetation_type == "Evergreen":
+            Pscale = 1
+
         df[(vegetation_type, 'Pscale')] = Pscale
+
 
         gee  = (
             df_vprm.loc[vegetation_type, "lambda"]


### PR DESCRIPTION
This updates the current vprm code with sandro's modifications


Pscale is 1 during phase two (Mahadevan et al, paragraph [14])to detect phase two occurrence let's use a EVI threshold method
see WRF-GHG https://github.com/wrf-model/WRF/blob/f34b11dbb89c002c5c0dca1195aab35daeed7349/chem/module_ghg_fluxes.F#L199
see pyVPRM https://github.com/tglauch/pyVPRM/blob/308421b3f1ade445fef1b9edc37547db83a295cb/pyVPRM/VPRM.py#L561


since it's not simple to get vegetation dynamics on Sentinel2 (while it's available for MOD12Q2 used by Mahadevan et al., 2008), the overall max and min of EVI is used, not the EVI max/min during growing phase only (as it should be).