### PR TITLE
Update for 3.13

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.9", "3.13"]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Updated for python 3.13 release

* Tests should pass 


<!-- readthedocs-preview emiproc start -->
----
📚 Documentation preview 📚: https://emiproc--65.org.readthedocs.build/en/65/

<!-- readthedocs-preview emiproc end -->