### PR TITLE
Small fixes for the docs: typos, formatting, links, duplications

### DIFF
--- a/docs/source/api/inventories.rst
+++ b/docs/source/api/inventories.rst
@@ -45,3 +45,6 @@ Available Inventories
 
 .. autoclass:: emiproc.inventories.gral.GralInventory
     :special-members: __init__
+
+.. autoclass:: emiproc.inventories.cams_reg_aq.CAMS_REG_AQ
+    :special-members: __init__

--- a/docs/source/emissions_generation.rst
+++ b/docs/source/emissions_generation.rst
@@ -32,4 +32,4 @@ Human Respiration
 Human respirations can be generated using maps of population density and 
 emission factors per person.
 
-see :py:mod:`emiproc.human_respiration
+see :py:mod:`emiproc.human_respiration`

--- a/docs/source/tutos/tutorials.rst
+++ b/docs/source/tutos/tutorials.rst
@@ -17,7 +17,6 @@ https://github.com/C2SM-RCM/emiproc/tree/master/examples
 Scripts 
 -------
 
-Scripts were create on some dedicated cases. They are not well documented
 Scripts were created for some dedicated cases. They are not well documented, but there are many scripts for different cases.
 https://github.com/C2SM-RCM/emiproc/tree/master/scripts
 

--- a/docs/source/tutos/tutorials.rst
+++ b/docs/source/tutos/tutorials.rst
@@ -4,8 +4,8 @@ Tutorials
 If you want to start using emiproc, we recommend beginning with the tutorials below.
 They will guide you through the main features of emiproc.
 
-Additionally many examples of using emiproc can be found
 Additionally, many examples of using emiproc can be found in the GitHub repository.
+
 Examples 
 --------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,5 +67,6 @@ doc = [
     "enum-tools",
     "sphinx_toolbox",
     "nbsphinx",
+    "ipython",
 ]
 dev = ["black", "pytest"]


### PR DESCRIPTION
While doing the JOSS review, I noticed a few minor issues in the (otherwise very helpful) docs.

The `ipython` dependency for the docs is necessary to get proper syntax highlighting, otherwise sphinx complains with a warning.

<!-- readthedocs-preview emiproc start -->
----
📚 Documentation preview 📚: https://emiproc--74.org.readthedocs.build/en/74/

<!-- readthedocs-preview emiproc end -->