### PR TITLE
Fix gfed

### DIFF
--- a/emiproc/exports/wrf.py
+++ b/emiproc/exports/wrf.py
@@ -119,6 +119,9 @@ class WRF_Grid(RegularGrid):
 
         self.cells_as_polylist = polys
 
+    def __repr__(self) -> str:
+        return f"WRF_grid({self.name})_nx({self.nx})_ny({self.ny})"
+
 
 def export_wrf_hourly_emissions(
     inv: Inventory,

--- a/emiproc/inventories/gfed.py
+++ b/emiproc/inventories/gfed.py
@@ -180,7 +180,7 @@ class GFED4_Inventory(Inventory):
         # Now we make the profiles
 
         das_daily = []
-        year = 2018
+
         for month in range(1, 13):
             ds_daily = xr.open_dataset(
                 gfed_file, group=f"/emissions/{month:02}/daily_fraction"

--- a/emiproc/inventories/gfed.py
+++ b/emiproc/inventories/gfed.py
@@ -254,7 +254,9 @@ class GFED4_Inventory(Inventory):
             Hour3OfDayPerMonth: da_diurnal3_stacked.rename(
                 {"hour3_per_month": "ratio"}
             ).drop_vars("month"),
-            DayOfYearProfile: da_day_of_year_stacked.rename({"day": "ratio"}),
+            get_leap_year_or_normal(
+                DayOfYearProfile, year=year
+            ): da_day_of_year_stacked.rename({"day": "ratio"}),
             MounthsProfile: da_stacked.rename({"month": "ratio"}),
         }
 

--- a/emiproc/profiles/temporal/composite.py
+++ b/emiproc/profiles/temporal/composite.py
@@ -17,6 +17,24 @@ from emiproc.profiles.temporal.specific_days import SpecificDay
 logger = logging.getLogger(__name__)
 
 
+def rescale_ratios(ratios: np.ndarray) -> np.ndarray:
+    """Rescale the ratios to sum up to 1.
+
+    Profiles with ratios of only zeros will be set to constant profiles.
+
+    :arg ratios: The ratios to rescale.
+    """
+
+    sums = ratios.sum(axis=0)
+
+    mask_zero = sums == 0
+
+    return_ = ratios / sums
+    return_[:, mask_zero] = 1.0 / ratios.shape[0]
+
+    return return_
+
+
 class CompositeTemporalProfiles:
     """A helper class to handle mixtures of temporal profiles.
 
@@ -198,7 +216,7 @@ class CompositeTemporalProfiles:
         # Create the empty profiles
         profiles = [
             [
-                t((r / r.sum(axis=0)) if rescale else r)
+                t(rescale_ratios(r) if rescale else r)
                 for i, t in enumerate(types)
                 if not np.any(
                     np.isnan(r := profile_ratios[splitters[i] : splitters[i + 1]])

--- a/emiproc/tests_utils/temporal_profiles.py
+++ b/emiproc/tests_utils/temporal_profiles.py
@@ -1,10 +1,13 @@
 import random
+from dataclasses import dataclass, field
 from typing import Type
 
 import numpy as np
 import xarray as xr
 
 import emiproc
+from emiproc.profiles.temporal.composite import CompositeTemporalProfiles
+from emiproc.profiles.temporal.io import from_csv
 from emiproc.profiles.temporal.profiles import (
     AnyTimeProfile,
     DailyProfile,
@@ -14,8 +17,6 @@ from emiproc.profiles.temporal.profiles import (
     TemporalProfile,
     WeeklyProfile,
 )
-from emiproc.profiles.temporal.composite import CompositeTemporalProfiles
-from emiproc.profiles.temporal.io import from_csv
 
 copernicus_profiles_dir = emiproc.FILES_DIR / "profiles" / "copernicus"
 
@@ -207,3 +208,17 @@ indexes_african_2d = xr.DataArray(
         "category": ["liku", "blek", "test"],
     },
 )
+
+
+@dataclass(eq=False)
+class TestProfile2(TemporalProfile):
+    """Test profile of size 2."""
+
+    size: int = field(default=2, init=False)
+
+
+@dataclass(eq=False)
+class TestProfile3(TemporalProfile):
+    """Test profile of size 3."""
+
+    size: int = field(default=3, init=False)

--- a/tests/profiles/test_composite.py
+++ b/tests/profiles/test_composite.py
@@ -1,0 +1,48 @@
+"""Test composite profiles.
+
+.. note:: Some of the composite test are also in other files.
+
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from emiproc.profiles.temporal.profiles import TemporalProfile
+from emiproc.profiles.temporal.composite import CompositeTemporalProfiles
+from emiproc.tests_utils.temporal_profiles import TestProfile2, TestProfile3
+
+
+def test_from_ratios():
+
+    profile = CompositeTemporalProfiles.from_ratios(
+        ratios=np.array([[0.1, 0.9, 0.3, 0.5, 0.2]]),
+        types=[TestProfile2, TestProfile3],
+    )
+
+
+def test_from_rescale():
+
+    profile = CompositeTemporalProfiles.from_ratios(
+        ratios=np.array([[0.1, 0.2, 0.3, 0.5, 0.2]]),
+        types=[TestProfile2, TestProfile3],
+        rescale=True,
+    )
+
+
+def test_with_zero():
+    """Test when one of the profile is zero."""
+    profile = CompositeTemporalProfiles.from_ratios(
+        ratios=np.array([[0.0, 0.0, 0.3, 0.5, 0.2]]),
+        types=[TestProfile2, TestProfile3],
+        rescale=True,
+    )
+
+    # Will be replaced by a constant profile
+    # Test both, because it might be reversed
+    assert (
+        np.array_equal(profile.ratios, np.array([[0.5, 0.5, 0.3, 0.5, 0.2]]))
+        and profile.types == [TestProfile2, TestProfile3]
+    ) or (
+        np.array_equal(profile.ratios, np.array([[0.3, 0.5, 0.2, 0.5, 0.5]]))
+        and profile.types == [TestProfile3, TestProfile2]
+    )


### PR DESCRIPTION
Issue for gfed was discovered for leap year data, the wrong profile was used.

This caused another issue of division by 0 when 0 ratios were given to composite profiles.
This was fixed and tested.

This PR fixes these two problems.

<!-- readthedocs-preview emiproc start -->
----
📚 Documentation preview 📚: https://emiproc--87.org.readthedocs.build/en/87/

<!-- readthedocs-preview emiproc end -->