### PR TITLE
Fix remap not taking gdf

### DIFF
--- a/emiproc/plots/__init__.py
+++ b/emiproc/plots/__init__.py
@@ -164,7 +164,7 @@ def plot_inventory(
     :arg reverse_y: if True, will reverse the y-axis.
     :arg poly_collection_kwargs: additional keyword arguments for the PolyCollection.
     :arg country_borders_kwargs: additional keyword arguments for the country borders.
-        See `geopandas.Geoseries.plot` for more information. 
+        See `geopandas.Geoseries.plot` for more information.
     """
 
     logger = logging.getLogger(__name__)
@@ -307,13 +307,16 @@ def plot_inventory(
                     extent=[x_min, x_max, y_min, y_max],
                 )
             else:
+                # Plot only polygons, other wise, it will be wierd with the mulipolygon
+                # hiding parts of the grid
+                mask_polygons = (grid.gdf.geometry.geom_type == "Polygon").to_numpy()
                 im = PolyCollection(
-                    grid.corners,
+                    grid.corners[mask_polygons],
                     cmap=this_cmap,
                     norm=norm,
                     **poly_collection_kwargs,
                 )
-                im.set_array(emissions.flatten())
+                im.set_array(emissions.flatten()[mask_polygons])
                 ax.add_collection(im)
             add_ax_info(ax)
             ax.set_title(f"{sub} - {cat}: " f"{per_sector_emissions[cat]:.2} " f"kg/y")
@@ -363,13 +366,14 @@ def plot_inventory(
                 extent=[x_min, x_max, y_min, y_max],
             )
         else:
+            mask_polygons = (grid.gdf.geometry.geom_type == "Polygon").to_numpy()
             im = PolyCollection(
-                grid.corners,
+                grid.corners[mask_polygons],
                 cmap=this_cmap,
                 norm=norm,
                 **poly_collection_kwargs,
             )
-            im.set_array(total_sub_emissions.flatten())
+            im.set_array(total_sub_emissions.flatten()[mask_polygons])
             ax.add_collection(im)
 
         ax.set_title(

--- a/emiproc/regrid.py
+++ b/emiproc/regrid.py
@@ -417,7 +417,7 @@ def remap_inventory(
         weights_file = Path(weights_file)
 
     if isinstance(grid, Grid) or issubclass(type(grid), Grid):
-        grid_cells = gpd.GeoSeries(grid.cells_as_polylist, crs=grid.crs)
+        grid_cells = grid.gdf.geometry.reset_index(drop=True)
     elif isinstance(grid, gpd.GeoSeries):
         grid_cells = grid.reset_index(drop=True)
     else:

--- a/emiproc/tests_utils/test_grids.py
+++ b/emiproc/tests_utils/test_grids.py
@@ -7,9 +7,11 @@ from emiproc.grids import HexGrid, RegularGrid, GeoPandasGrid
 # Regular grid for testing
 # Note that this grid is big enough to include the inventories from the
 # test_utils/test_inventories.py module
-regular_grid = RegularGrid(
+reg_grid_kwargs = dict(
     xmin=-1, xmax=5, ymin=-2, ymax=3, nx=10, ny=15, name="Test Regular Grid"
 )
+regular_grid = RegularGrid(**reg_grid_kwargs)
+regular_grid_no_crs = RegularGrid(**reg_grid_kwargs, crs=None)
 
 hex_grid = HexGrid(xmin=-1, xmax=5, ymin=-2, ymax=3, nx=10, ny=15, name="Test Hex Grid")
 

--- a/tests/test_remap_inv.py
+++ b/tests/test_remap_inv.py
@@ -2,7 +2,7 @@ import pytest
 from emiproc.inventories import  EmissionInfo, Inventory
 from emiproc.regrid import remap_inventory
 from emiproc.tests_utils.test_inventories import inv_with_pnt_sources, inv_with_gdfs_bad_indexes, inv
-from emiproc.tests_utils.test_grids import regular_grid, gpd_grid
+from emiproc.tests_utils.test_grids import regular_grid, gpd_grid, regular_grid_no_crs
 from emiproc.tests_utils.temporal_profiles import three_composite_profiles, indexes_inv_catsubcell
 
 from emiproc.inventories.utils import get_total_emissions
@@ -13,8 +13,7 @@ from emiproc.utilities import total_emissions_almost_equal
 
 def test_remap():
 
-    grid = regular_grid
-    grid.crs = None
+    grid = regular_grid_no_crs
     remaped_inv = remap_inventory(inv_with_pnt_sources, grid)
 
     # Check the grid size
@@ -30,8 +29,7 @@ def test_remap():
 def test_remap_keep_shapes():
 
 
-    grid = regular_grid
-    grid.crs = None
+    grid = regular_grid_no_crs
     remaped_inv = remap_inventory(inv_with_pnt_sources, grid, keep_gdfs=True)
 
     # Check the grid size
@@ -56,9 +54,8 @@ def test_remap_keep_shapes():
 
 
 def test_remap_different_grids():
-    for grid in [regular_grid, gpd_grid]:
+    for grid in [regular_grid_no_crs, gpd_grid]:
         try:
-            grid.crs = None
             remaped_inv = remap_inventory(inv_with_pnt_sources, grid=grid)
         except Exception as e:
             raise AssertionError(f"Remapping failed for grid {grid.name}") from e
@@ -70,8 +67,7 @@ def test_remap_with_gdf_wrong_indices():
 
     inv = inv_with_gdfs_bad_indexes
 
-    regular_grid.crs = None
-    remapped = remap_inventory(inv, regular_grid)
+    remapped = remap_inventory(inv, regular_grid_no_crs)
 
 
 def test_remap_inv_with_profiles():


### PR DESCRIPTION
The remapping function was recreating a geoserie when a grid is given. 
This was an old behaviour which is now improved by taking the geoserie from the grid directly.

This showed some test with wrong crs behaviour which are now fixed.

Also fixes an issue with plotting grid with multipolygons (global icon grid).