### PR TITLE
Fix swiss plot

### DIFF
--- a/emiproc/inventories/swiss.py
+++ b/emiproc/inventories/swiss.py
@@ -263,10 +263,10 @@ class SwissRasters(Inventory):
         # Grid on which the inventory is created
         self.grid = SwissGrid(
             "ch_emissions",
-            nx=3600,
-            ny=2400,
-            xmin=2480000,
-            ymin=1060000,
+            ny=3600,
+            nx=2400,
+            ymin=2480000,
+            xmin=1060000,
             dx=self.edge_size,
             dy=self.edge_size,
             crs=LV95,

--- a/emiproc/plots/__init__.py
+++ b/emiproc/plots/__init__.py
@@ -170,8 +170,8 @@ def plot_inventory(
     logger = logging.getLogger(__name__)
 
     grid = inv.grid
-    if grid.crs == 2056: #swiss grid
-        grid_shape = (grid.ny,grid.nx)
+    if grid.crs == 2056: # swiss grid
+        grid_shape = (grid.nx,grid.ny)
     else:
         grid_shape = (grid.nx, grid.ny)
     is_regular = issubclass(type(grid), RegularGrid)
@@ -201,7 +201,10 @@ def plot_inventory(
         logger.info("Only one category, will plot only the total emissions")
         total_only = True
 
-    x_min, y_min, x_max, y_max = grid.gdf.total_bounds
+    if grid.crs == 2056: # need to transpose swiss grid
+        y_min, x_min, y_max, x_max = grid.gdf.total_bounds
+    else:
+        x_min, y_min, x_max, y_max = grid.gdf.total_bounds
 
     if not spec_lims:
         spec_lims = (x_min, x_max, y_min, y_max)
@@ -306,12 +309,12 @@ def plot_inventory(
 
             norm, this_cmap = get_norm_and_cmap(emission_non_zero_values)
             if is_regular:
-                if grid.crs == 2056:
+                if grid.crs == 2056: # need to transpoe swiss grid
                     im = ax.imshow(
-                        emissions.T[:, ::-1],
+                        emissions.T[:,::-1], 
                         norm=norm,
                         cmap=this_cmap,
-                        extent=[x_min, x_max, y_min, y_max],
+                        extent=[x_min, x_max, y_min, y_max ],
                     )
                 else:
                     im = ax.imshow(
@@ -373,13 +376,14 @@ def plot_inventory(
         norm, this_cmap = get_norm_and_cmap(emission_non_zero_values)
 
         if is_regular:
-            if grid.crs == 2056:
+            if grid.crs == 2056: # need to transpose swiss grid
                 im = ax.imshow(
-                    total_sub_emissions.T[:, ::-1],
+                    total_sub_emissions.T[:,::-1], 
                     norm=norm,
                     cmap=this_cmap,
-                    extent=[x_min, x_max, y_min, y_max],
+                    extent=[x_min, x_max, y_min, y_max, ],
                 )
+                ax.invert_yaxis() 
             else:
                 im = ax.imshow(
                     total_sub_emissions,


### PR DESCRIPTION
The plotting of emission data in the swissraster was not working. The dimensions of the created grid and the raster files did not match (2:3 instead of 3:2), creating duplicate data and a distorted figure. To fix this, I took the following steps:

- Swapping x and y dimensions when creating swiss_raster to fit the dimension of the rasters being read from file
- transposing emissions and inverting one axis when plotting to ensure right orientation. 
- get country borders in crs of swiss_raster

In order to ensure functionality with other inventories remains, the changes in the plotting function are behind if statements.

<!-- readthedocs-preview emiproc start -->
----
📚 Documentation preview 📚: https://emiproc--99.org.readthedocs.build/en/99/

<!-- readthedocs-preview emiproc end -->