### PR TITLE
Fix TypeError in plot_inventory for monthly-only temporal profiles

### DIFF
--- a/emiproc/plots/__init__.py
+++ b/emiproc/plots/__init__.py
@@ -511,9 +511,7 @@ def plot_inventory(
             min_value, max_value = 0, 0
             x = da.time.values
             if method == "step":
-                x = np.append(
-                    x, x[-1] + pd.to_timedelta(da.time.diff("time").mean().values)
-                )
+                x = np.append(x, x[-1] + da.time.diff("time").mean().values)
             total = np.zeros_like(x, dtype=float)
             for cat in sorted(inv.categories):
                 serie = da.sel(category=cat, substance=sub).values

--- a/emiproc/tests_utils/test_inventories_with_profiles.py
+++ b/emiproc/tests_utils/test_inventories_with_profiles.py
@@ -1,0 +1,28 @@
+"""Test inventories with temporal profiles."""
+
+from emiproc.profiles.temporal.composite import CompositeTemporalProfiles
+from emiproc.tests_utils.temporal_profiles import indexes_inv_catsub, three_profiles
+from emiproc.tests_utils.test_inventories import inv
+
+weekly_and_monthly_profiles = CompositeTemporalProfiles(
+    three_profiles + [three_profiles[0]]
+)
+monthly_profiles = CompositeTemporalProfiles(
+    [[profiles[1]] for profiles in three_profiles] + [[three_profiles[0][1]]]
+)
+
+inv_with_weekly_and_monthly_profiles = inv.copy()
+inv_with_weekly_and_monthly_profiles.set_profiles(
+    weekly_and_monthly_profiles, indexes=indexes_inv_catsub
+)
+
+inv_with_monthly_profiles = inv.copy()
+inv_with_monthly_profiles.set_profiles(monthly_profiles, indexes=indexes_inv_catsub)
+
+# Set a year
+for inv_ in [inv_with_weekly_and_monthly_profiles, inv_with_monthly_profiles]:
+    inv_.year = 2018
+
+# Exposed inventories for testing
+inv_with_weekly_and_monthly_profiles
+inv_with_monthly_profiles

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -68,9 +68,3 @@ def test_plot_inventory(inventory, plot_inventory_kwargs):
             run_plot()
     else:
         run_plot()
-
-
-if __name__ == "__main__":
-    matplotlib.use("qtagg")
-
-    plot_inventory(inv_with_monthly_profiles)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -11,6 +11,10 @@ from emiproc.tests_utils.test_inventories import (
     inv_on_grid_serie2,
     inv_with_pnt_sources,
 )
+from emiproc.tests_utils.test_inventories_with_profiles import (
+    inv_with_monthly_profiles,
+    inv_with_weekly_and_monthly_profiles,
+)
 
 matplotlib.use("Agg")
 
@@ -29,6 +33,11 @@ def plot_test_context():
         pytest.param(inv_on_grid_serie2, id="inv_on_grid_serie2"),
         pytest.param(inv_with_pnt_sources, id="inv_with_pnt_sources"),
         pytest.param(african_inv_regular_grid, id="african_inv_regular_grid"),
+        pytest.param(inv_with_monthly_profiles, id="inv_with_monthly_profiles"),
+        pytest.param(
+            inv_with_weekly_and_monthly_profiles,
+            id="inv_with_weekly_and_monthly_profiles",
+        ),
     ]
 )
 def inventory(request):
@@ -59,3 +68,9 @@ def test_plot_inventory(inventory, plot_inventory_kwargs):
             run_plot()
     else:
         run_plot()
+
+
+if __name__ == "__main__":
+    matplotlib.use("qtagg")
+
+    plot_inventory(inv_with_monthly_profiles)


### PR DESCRIPTION
plotting function was broken for purely monthly profiles due to different time types. 

<!-- readthedocs-preview emiproc start -->
----
📚 Documentation preview 📚: https://emiproc--146.org.readthedocs.build/en/146/

<!-- readthedocs-preview emiproc end -->