### PR TITLE
Generation of emission files for GRAL for Zurich

### DIFF
--- a/emiproc/exports/gral.py
+++ b/emiproc/exports/gral.py
@@ -2,9 +2,10 @@
 
 This module contains functions to prepare emissions for GRAL.
 
-Gral only has one polluant available, but can contain more than one category.
-
-To counter that issue, we make a source group for each substance/category.
+Different pollutants and emission categories can be simulated in a single
+GRAL simulation. They pollutant/category combinations are identified by a 
+unique source_group number stored in the EmissionsInfo structure of the
+inventory.
 
 
 .. warning:: For PM, it seems that there are some additional parameters:
@@ -13,7 +14,7 @@ To counter that issue, we make a source group for each substance/category.
 
     We don't use them for now.
 
-.. warning:: The current version of emiproc does not support lines and portals.
+.. warning:: The current version of emiproc does not support portals.
 
 
 4 types of emissions are supported with their respective files:
@@ -30,7 +31,7 @@ The following methods are applied:
 
 - points: simply write the coordinates and the emission rate
 - lines: write the coordinates of the line and the emission rate
-    The Multi-lines have to be split into single lines, which increases the
+    Multi-lines have to be split into single lines, which increases the
     size of the problem.
 - areas: polygons have to be rasterized into squares before writing them.
 - tunnels: not implemented
@@ -79,13 +80,6 @@ class EmissionWriter:
         self.grid = grid
         self.polygon_raster_size = polygon_raster_size
 
-        # Maps the (cat/sub) to source groups
-        self.source_groups = {
-            (sub, cat): i * len(self.inventory.categories) + j
-            for i, sub in enumerate(self.inventory.substances)
-            for j, cat in enumerate(self.inventory.categories)
-        }
-
         self._make_files()
 
     def _make_files(self):
@@ -129,18 +123,19 @@ class EmissionWriter:
             f.write(header)
 
         # File to save the source groups values
-        self.file_source_groups = self.path / "source_groups.json"
-        with open(self.file_source_groups, "w") as f:
-            # reverse the dict (items become keys and vice versa)
-            reversed_source_groups = {v: k for k, v in self.source_groups.items()}
-            json.dump(reversed_source_groups, f, indent=2)
+        # this json file needs to be written elsewhere since the necessary
+        # information is not provided with the inventory
+#        self.file_source_groups = self.path / "source_groups.json"
+#        with open(self.file_source_groups, "w") as f:
+#            # reverse the dict (items become keys and vice versa)
+#            reversed_source_groups = {v: k for k, v in self.source_groups.items()}
+#            json.dump(reversed_source_groups, f, indent=2)
 
     def write_gdfs(self):
         """Write the gdfs emissions to the files."""
         for cat, gdf in self.inventory.gdfs.items():
             info = self.inventory.emission_infos[cat]
             for sub in self.inventory.substances:
-                source_group = self.source_groups[(sub, cat)]
                 if sub not in gdf.columns:
                     continue
 
@@ -148,21 +143,21 @@ class EmissionWriter:
                 if any(mask_polygons):
                     gdf_polygons = gdf.loc[mask_polygons]
                     self._write_polygons(
-                        gdf_polygons.geometry, gdf_polygons[sub], info, source_group
+                        gdf_polygons.geometry, gdf_polygons[sub], info
                     )
 
                 mask_points = gdf.geom_type == "Point"
                 if any(mask_points):
                     gdf_points = gdf.loc[mask_points]
                     self._add_points(
-                        gdf_points.geometry, gdf_points[sub], info, source_group
+                        gdf_points.geometry, gdf_points[sub], info
                     )
 
                 mask_lines = gdf.geom_type.isin(["LineString"])
                 if any(mask_lines):
                     gdf_lines = gdf.loc[mask_lines]
                     self._write_lines(
-                        gdf_lines.geometry, gdf_lines[sub], info, source_group
+                        gdf_lines.geometry, gdf_lines[sub], info
                     )
 
                 mask_multilines = gdf.geom_type.isin(["MultiLineString"])
@@ -176,7 +171,7 @@ class EmissionWriter:
                         proprtions = lenghts / shape.length
                         for line, prop in zip(shape.geoms, proprtions):
                             self._write_line(
-                                line, shape_emission * prop, info, source_group
+                                line, shape_emission * prop, info
                             )
                 mask_missing = ~(
                     mask_multilines | mask_lines | mask_points | mask_polygons
@@ -199,7 +194,6 @@ class EmissionWriter:
         shapes: gpd.GeoSeries,
         emissions: pd.Series,
         info: EmissionInfo,
-        source_group: int,
     ):
         z = info.height
         if info.height_over_buildings:
@@ -218,7 +212,7 @@ class EmissionWriter:
                     "exit_velocity[m/s]": info.speed,
                     "diameter[m]": info.width,
                     "temperature[K]": info.temperature,
-                    "source_group": source_group,
+                    "source_group": info.source_group,
                 }
             )
         )
@@ -228,17 +222,15 @@ class EmissionWriter:
         shapes: gpd.GeoSeries,
         emissions: pd.Series,
         info: EmissionInfo,
-        source_group: int,
     ):
         for shape, emission in zip(shapes, emissions):
-            self._write_line(shape, emission, info, source_group)
+            self._write_line(shape, emission, info)
 
     def _write_line(
         self,
         shape: LineString,
         emission: float,
         info: EmissionInfo,
-        source_group: int,
     ):
         """Write a line source to the file."""
         # split the line string in single lines
@@ -257,7 +249,6 @@ class EmissionWriter:
                 Point(line.coords[1]),
                 line_emission,
                 info,
-                source_group,
                 section=i,
             )
 
@@ -267,7 +258,6 @@ class EmissionWriter:
         end: Point,
         emission: float,
         info: EmissionInfo,
-        source_group: int,
         section: int,  # Section number of the line
     ):
         """Write a straight line source to the file."""
@@ -280,7 +270,7 @@ class EmissionWriter:
         with open(self.file_lines, "a") as f:
             # Write the line
             f.write(
-                f"unnamed,{section},{source_group},{start.x},{start.y},{z_start},"
+                f"0,{section},{info.source_group},{start.x},{start.y},{z_start},"
                 f"{end.x},{end.y},{z_end},{info.width},-{info.vertical_extension},0,0,"
                 f"{emission},0,0,0,0\n"
             )
@@ -290,7 +280,6 @@ class EmissionWriter:
         shapes: Iterable[Polygon],
         emissions: Iterable[float],
         info: EmissionInfo,
-        source_group: int,
     ):
         """Write a polygon source to the file."""
 
@@ -326,7 +315,7 @@ class EmissionWriter:
                 f.write(
                     f"{x[i_x]},{y[i_y]},{info.height},"
                     f"{self.polygon_raster_size},{self.polygon_raster_size},{info.vertical_extension},"
-                    f"{rasterized_emissions[i_x, i_y]},0,0,0,{source_group},\n"
+                    f"{rasterized_emissions[i_x, i_y]},0,0,0,{info.source_group},\n"
                 )
 
 
@@ -334,7 +323,6 @@ def export_to_gral(
     inventory: Inventory,
     grid: GralGrid,
     path: os.PathLike,
-    polygon_raster_size: float = 1.0,
 ) -> None:
     """Export an inventory to GRAL.
 
@@ -344,6 +332,11 @@ def export_to_gral(
     :param path: Path where to write the emissions.
     :param grid: Grid to use.
     """
+
+    if grid.dy != grid.dx:
+        raise ValueError(f"GRAL grid must have identical dx and dy values")
+
+    polygon_raster_size = grid.dx
 
     writer = EmissionWriter(Path(path), inventory, grid, polygon_raster_size)
 

--- a/emiproc/inventories/__init__.py
+++ b/emiproc/inventories/__init__.py
@@ -49,27 +49,29 @@ class EmissionInfo:
 
     :param height: The height of the emission source (over the ground). [m]
     :param height_over_buildings: If True, the height is taken over buildings.
-    :param width: The width of the emission source. [m]
+    :param width: The width of the line emission source. [m]
     :param vertical_extension:
         The vertical extension (thickness) of the emission source. [m]
         This implies that the emission starts at height
         and ends at height + vertical_extension.
-    :param temperature: The temperature of the emission source. [K]
-    :param speed: The speed of the emission of the substances. [m/s]
+    :param temperature: The temperature of the point source emission. [K]
+    :param speed: The speed of the emission of the point source emission. [m/s]
     :param comment: A comment about the emission source.
+    :param source_group: Source group to which this source belongs.
 
     """
 
     # Height
     height: float = 0.0
-    # weight the height is taken over buildings
+    # whether the height is taken over buildings
     height_over_buildings: bool = True
 
-    width: float = 0.5
+    width: float = 0.5          # only relevant for line sources
     vertical_extension: float = 3.0
-    temperature: float = 353.0
-    speed: float = 5.0
+    temperature: float = 353.0  # only relevant for point sources
+    speed: float = 5.0          # only relevant for point sources
     comment: str = ""
+    source_group: int = 0       # GRAMM/GRAL source group
 
 
 class Inventory:

--- a/emiproc/inventories/swiss.py
+++ b/emiproc/inventories/swiss.py
@@ -48,6 +48,7 @@ class SwissRasters(Inventory):
         rasters_str_dir: PathLike,
         requires_grid: bool = True,
         year: int = 2015,
+        substances: list[Substance] | None = None,
         point_source_correction: dict[
             Category, PointSourceCorrection
         ] = default_point_source_correction,
@@ -59,23 +60,29 @@ class SwissRasters(Inventory):
         :arg filepath_point_sources: Excel file containing point sources.
             See in :py:func:`emiproc.inventories.swiss.read_prtr` for more details.
         :arg rasters_dir: The folder where the rasters are found.
-        :arg rasters_str_dir: The folder where the rasters pro substance are found.
+        :arg rasters_str_dir: The folder where the substance-specific rasters are found.
         :arg requires_grid: Whether the grid should be created as well.
-            Creating the shapes for the swiss grid is quite expensive process.
+            Creating the shapes for the swiss grid is quite an expensive process.
             Most of the weights for remapping can be cached so if you
             have them generated already, set that to false.
         :arg year: The year of the inventory that should be used.
             This should be present in the `Emissions_CH.xlsx` file.
             The raster files are the same for all years. Only the scaling
-            of the full raster pro substance changes.
+            of the full raster per substance changes.
+        :arg substances: List of substances to use.
+            If None, all substances in the totals file will be used.
         """
         super().__init__()
 
         self.year = year
 
+        # ---------------------------------------------------------------------
+        # -- Total emissions per category and substance
+        # ---------------------------------------------------------------------
+
         filepath_csv_totals = Path(filepath_csv_totals)
 
-        # Emission data file
+        # Data file with emission totals for different years
         if filepath_csv_totals.is_file():
             total_emission_file = filepath_csv_totals
         else:
@@ -83,7 +90,7 @@ class SwissRasters(Inventory):
                 f"Data path {filepath_csv_totals} is not an existing file or a folder."
             )
 
-        # Load excel sheet with the total emissions (excluding point sources)
+        # Load csv file with total emissions for different years
         df_emissions = pd.read_csv(total_emission_file, comment="#")
 
         # Add indexing column consisting of both grid and species' name
@@ -103,8 +110,18 @@ class SwissRasters(Inventory):
 
         emissions = df_emissions[year_str].copy()
 
-        # List with substance
-        substances = df_emissions["substance"].unique()
+        # List with substances to be used in the inventory. 
+        # If None, all substances in the dataset will be used.
+        if substances is None:
+            substances = df_emissions["substance"].unique()
+        else:
+            for sub in substances:
+                if sub not in df_emissions["substance"].unique():
+                    raise ValueError(
+                        f"Substance {sub} not in dataset with substances={df_emissions['substance'].unique()}."
+                    )
+            # remove all entries in df_emissions that are not in the list of substances
+            emissions = emissions[emissions.index.str.split("_").str[1].isin(substances)]
 
         # ---------------------------------------------------------------------
         # -- Emissions from point sources
@@ -113,7 +130,7 @@ class SwissRasters(Inventory):
         # Load data
         gdfs = read_prtr(filepath_point_sources, year, substances=substances)
 
-        # Remove the total values in the rasters
+        # Remove the total point source values from the rasters to avoid double counting
         for cat, gdf in gdfs.items():
 
             if "CO2" in gdf.columns:
@@ -128,17 +145,17 @@ class SwissRasters(Inventory):
                     point_source_correction[cat]
                     == PointSourceCorrection.IS_ONLY_POINT_SOURCE
                 ):
-                    biog_fracton = 0.0
+                    biog_fraction = 0.0
                 else:
-                    # Get the biogenic fraction in the total emissions
-                    # and apply it to the pointsources
-                    biog_fracton = emissions.loc[catsub_biog] / (
+                    # Get the biogenic fraction from the raster emissions and use it
+                    # to split the CO2 in the point sources assuming the same fraction
+                    biog_fraction = emissions.loc[catsub_biog] / (
                         emissions.loc[catsub_co2] + emissions.loc[catsub_biog]
                     )
-                # Split the CO2 emissions in two
+                # Split the CO2 point source emissions in two
                 base_col = gdf["CO2"].copy()
-                gdf["CO2"] = base_col * (1.0 - biog_fracton)
-                gdf["CO2_biog"] = base_col * biog_fracton
+                gdf["CO2"] = base_col * (1.0 - biog_fraction)
+                gdf["CO2_biog"] = base_col * biog_fraction
 
             totals = gdf.drop(columns=["geometry"]).sum(axis="rows")
             for sub in totals.index:
@@ -188,19 +205,28 @@ class SwissRasters(Inventory):
                 else:
                     raise ValueError(f"Unknown correction {correction}")
 
-        # ---------------------------------------------------------------------
-        # -- Grids
-        # ---------------------------------------------------------------------
+        # ---------------------------------------------------------------------------
+        # -- Get category-specific raster grids and distribute emissions to the grid
+        # ---------------------------------------------------------------------------
 
         rasters_dir = Path(rasters_dir)
 
         # Grids that depend on substance (road transport)
         rasters_str_dir = Path(rasters_str_dir)
+        raster_substances = {
+            "nmvoc" if substance.lower() == "voc" else substance.lower()
+            for substance in substances
+        }
+        # get rasters only for our list of substances
         str_rasters = [
             r
             for r in rasters_str_dir.glob("*.asc")
             # Don't include the tunnel specific grids as they are already included in the grids for road transport
             if "_tun" not in r.stem
+            and any(
+                r.stem.lower().endswith(f"_{substance}")
+                for substance in raster_substances
+            )
         ]
 
         # Grids that do not depend on substance
@@ -212,23 +238,34 @@ class SwissRasters(Inventory):
             r.stem for r in str_rasters
         ]
 
-        # List with Raster categories for which we have emissions
+        # Create list with Raster categories for which we have non-zero emissions
         raster_sub = emissions.index.tolist()
-        rasters_w_emis = []
-
-        evstr_subname_to_subname = {}
+        # We have to deal with the fact that the split traffic categories 
+        # f1, f2, f3, f4 are all mapped to the same raster category (evstr or evzon)
+        # and that the non-methane VOCs are mapped to the "evstr_nmvoc" raster category.
+        raster_emission_mapping = {}
         for t in raster_sub:
+            if emissions.loc[t] == 0:
+                continue
             split = t.split("_")
             assert len(split) > 1
             cat = split[0]
             sub = "_".join(split[1:])
+            if cat == "na":
+                # For the "na" category (e.g. flight traffic) we do 
+                # not have an emission raster.
+                continue
+            raster_cat = cat.replace("f1", "").replace("f2", "")
+            raster_cat = raster_cat.replace("f3", "").replace("f4", "")
             if "evstr" in cat:
                 # Grid for non-methane VOCs is named "evstr_nmvoc"
                 subname = sub.lower()
                 if subname == "voc":
                     subname = "nmvoc"
-                rasters_w_emis.append(cat + "_" + subname)
-                evstr_subname_to_subname[subname] = sub
+                raster_category = raster_cat + "_" + subname
+                raster_emission_mapping.setdefault(raster_category, []).append(
+                    (cat, sub)
+                )
             elif (
                 cat in point_source_correction
                 and point_source_correction[cat]
@@ -237,23 +274,18 @@ class SwissRasters(Inventory):
                 # If the category is only point source, we don't need the raster
                 pass
             else:
-                rasters_w_emis.append(cat)
-        # Remove duplicates
-        rasters_w_emis = [*set(rasters_w_emis)]
+                raster_emission_mapping.setdefault(raster_cat, []).append((cat, sub))
 
-        # Compare Raster categories of input emission file with Raster categories of grids
-        # Raise error if the two don't agree
-        if not sorted(self.raster_categories) == sorted(rasters_w_emis):
-            missing_raster_files = [
-                r for r in rasters_w_emis if r not in self.raster_categories
-            ]
-            missing_emissions_values = [
-                r for r in self.raster_categories if r not in rasters_w_emis
-            ]
+        raster_categories_w_emis = list(raster_emission_mapping)
+
+        # Compare raster categories with non-zero emissions to available grids.
+        missing_raster_files = [
+            r for r in raster_categories_w_emis if r not in self.raster_categories
+        ]
+        if missing_raster_files:
             raise ValueError(
                 "Raster categories of emission file don't match:"
                 f"\nMissing raster files: {missing_raster_files}"
-                f"\nMissing emissions values: {missing_emissions_values}"
             )
 
         # ---------------------------------------------------------------------
@@ -278,27 +310,31 @@ class SwissRasters(Inventory):
         mapping = {}
 
         # Loading Raster categories and assigning respective emissions
-        for raster_file, category in zip(self.all_raster_files, self.raster_categories):
+        rasters_w_emis = [
+            (raster_file, category)
+            for raster_file, category in zip(
+                self.all_raster_files, self.raster_categories
+            )
+            if category in raster_categories_w_emis
+        ]
+        for raster_file, category in rasters_w_emis:
             # Apply reshaping to correspond to emiproc grid definition
             _raster_array = self.load_raster(raster_file).T[:, ::-1].reshape(-1)
-            if "_" in category:
-                split = category.split("_")
-                cat = split[0]
-                sub = "_".join(split[1:])
-                sub_name = evstr_subname_to_subname[sub]
-                idx = cat + "_" + sub_name
-                total_emissions = emissions.loc[idx]
-                # Normalize the array to ensure the factor will be the sum
-                # Note: this is to ensure consistency if the data provider
-                # change the df_emission values in the future but not the rasters
-                _normalized_raster_array = _raster_array / _raster_array.sum()
-                mapping[(cat, sub_name)] = _normalized_raster_array * total_emissions
-            else:
-                for sub in substances:
-                    idx = category + "_" + sub
-                    total_emissions = emissions.loc[idx]
-                    if total_emissions > 0:
-                        mapping[(category, sub)] = _raster_array * total_emissions
+
+            # we need to loop over all the categories and substances that are mapped 
+            # to this raster category (e.g., evstrf1, evstrf2, evstrf3, evstrf4 are all mapped to evstr)
+            for cat, sub in raster_emission_mapping[category]:
+                #print("mapping", cat, sub, "to raster", category)
+                if "evstr" in cat:
+                    # Normalize the array to ensure the factor will be the sum
+                    # Note: this is to ensure consistency if the data provider
+                    # change the df_emission values in the future but not the rasters
+                    _normalized_raster_array = _raster_array / _raster_array.sum()
+                    mapping[(cat, sub)] = _normalized_raster_array * emissions.loc[
+                        cat + "_" + sub
+                    ]
+                elif emissions.loc[cat + "_" + sub] > 0:
+                    mapping[(cat, sub)] = _raster_array * emissions.loc[cat + "_" + sub]
 
         self.gdf = gpd.GeoDataFrame(
             mapping,
@@ -355,6 +391,8 @@ polluant_matching = {
     # 'Cadmium und Verbindungen (als Cd)',
     # 'Zink und Verbindungen (als Zn)',
     "Feinstaub (PM10)": "PM10",
+    "Feinstaub (PM2.5)": "PM10",
+    "Black Carbon": "BC",
     # 'Fluor und anorganische Verbindungen (als HF)',
     # 'Chlor und anorganische Verbindungen (als HCl)',
     "Methan (CH4)": "CH4",

--- a/emiproc/inventories/zurich/categories_info.py
+++ b/emiproc/inventories/zurich/categories_info.py
@@ -2,8 +2,114 @@
 
 from emiproc.inventories import EmissionInfo
 
+# default values are 
+# height = 0.0
+# height_over_buildings = True
+# with = 0.5
+# vertical_extension = 3.0
+# temperature = 353.0
+# speed = 5.0
+# source_group = 0 # to be changed later
+
 LARGE_ROAD_TRANSPORT = EmissionInfo(height=0.3, width=7.0)
 ZURICH_SOURCES = {
+    "c1101_Linienschiffe_Emissionen": EmissionInfo(height=1.5, width=5.0),
+    "c1102_PrivaterBootsverkehr_Emissionen": EmissionInfo(height=0.5),
+    "c1201_BahnPersonenverkehr_Emissionen": EmissionInfo(height=0.3, width=3.0),
+    "c1202_BahnGueterverkehr_Emissionen": EmissionInfo(height=0.3, width=3.0),
+    "c1203_Tramverkehr_Emissionen": EmissionInfo(height=0.3, width=2.0),
+    "c1204_Kleinbahnen_Emissionen": EmissionInfo(height=0.3, width=2.0),
+    "c1301_Personenwagen_Emissionen": LARGE_ROAD_TRANSPORT,
+    "c1302_Lastwagen_Emissionen": LARGE_ROAD_TRANSPORT,
+    "c1303_Motorraeder_Emissionen": LARGE_ROAD_TRANSPORT,
+    "c1304_Linienbusse_Emissionen": LARGE_ROAD_TRANSPORT,
+    "c1305_Trolleybusse_Emissionen": LARGE_ROAD_TRANSPORT,
+    "c1306_StartStopTankatmung_Emissionen": EmissionInfo(height=0.3),
+    "c1307_Lieferwagen_Emissionen": LARGE_ROAD_TRANSPORT,
+    "c1308_Reisebusse_Emissionen": LARGE_ROAD_TRANSPORT,
+    "c2101_Oelheizungen_Emissionen": EmissionInfo(height=3.0),
+    "c2102_Gasheizungen_Emissionen": EmissionInfo(height=3.0),
+    "c2103_HolzheizungenLokalisiert_Emissionen": EmissionInfo(height=3.0),
+    "c2104_HolzheizungenDispers_Emissionen": EmissionInfo(height=3.0),
+    "c2105_Warmwassererzeuger_Emissionen": EmissionInfo(height=3.0),
+    "c2201_BHKW_Emissionen": EmissionInfo(height=3.0),
+    "c2301_KHKWKehricht_Emissionen": EmissionInfo(),
+    "c2302_KHKWErdgas_Emissionen": EmissionInfo(),
+    "c2303_KHKWHeizoel_Emissionen": EmissionInfo(),
+    "c2401_Klaerschlammverwertung_Emissionen": EmissionInfo(
+        comment="new junk Cat, group with other category?",
+    ),
+    "c3101_MaschinenHochbau_Emissionen": EmissionInfo(
+        comment="new Cat for construction related"
+    ),
+    "c3102_Bitumen_Emissionen": EmissionInfo(
+        comment="new Cat for construction related"
+    ),
+    "c3103_FarbenBaustelle_Emissionen": EmissionInfo(
+        comment="new Cat for construction related"
+    ),
+    "c3104_MaschinenTiefbau_Emissionen": EmissionInfo(
+        comment="new Cat for construction related"
+    ),
+    "c3105_Strassenbelag_Emissionen": EmissionInfo(
+        comment="new Cat for construction related"
+    ),
+    "c3201_Notstromanlagen_Emissionen": EmissionInfo(height=3.0),
+    "c3301_Prozessenergie_Emissionen": EmissionInfo(height=3.0),
+    "c3401_Metallreinigung_Emissionen": EmissionInfo(),
+    "c3402_Holzbearbeitung_Emissionen": EmissionInfo(),
+    "c3403_Malereien_Emissionen": EmissionInfo(),
+    "c3404_Textilreinigung_Emissionen": EmissionInfo(),
+    "c3405_Karosserien_Emissionen": EmissionInfo(),
+    "c3406_Raeuchereien_Emissionen": EmissionInfo(height=3.0),
+    "c3407_Roestereien_Emissionen": EmissionInfo(height=3.0),
+    "c3408_Druckereien_Emissionen": EmissionInfo(),
+    "c3409_Laboratorien_Emissionen": EmissionInfo(),
+    "c3410_Bierbrauereien_Emissionen": EmissionInfo(),
+    "c3411_Brotproduktion_Emissionen": EmissionInfo(),
+    "c3412_MedizinischePraxen_Emissionen": EmissionInfo(),
+    "c3413_Gesundheitswesen_Emissionen": EmissionInfo(),
+    "c3414_Krematorium_Emissionen": EmissionInfo(),
+    "c3415_Kompostierung_Emissionen": EmissionInfo(),
+    "c3416_Tankstellen_Emissionen": EmissionInfo(),
+    "c3417_LoesemittelIG_Emissionen": EmissionInfo(
+        comment="new Cat for solvents"
+    ),
+    "c3418_Vergaerwerk_Emissionen": EmissionInfo(
+        comment="new Cat, group with other category?"
+    ),
+    "c3419_IndustrielleFZ_Emissionen": EmissionInfo(
+        comment="added to Agri/Forest vehicel emission",
+    ),
+    "c4101_ForstwirtschaftlicheFZ_Emissionen": EmissionInfo(width=7.0),
+    "c4201_LandwirtschaftlicheFZ_Emissionen": EmissionInfo(),
+    "c4301_Nutzflaechen_Emissionen": EmissionInfo(),
+    "c4401_Nutztierhaltung_Emissionen": EmissionInfo(),
+    "c5101_LoesemittelHH_Emissionen": EmissionInfo(
+        comment="new Cat for solvents"
+    ),
+    "c5201_Gruenabfallverbrennung_Emissionen": EmissionInfo(),
+    "c5301_HolzoefenKleingarten_Emissionen": EmissionInfo(),
+    "c5401_AbfallverbrennungHaus_Emissionen": EmissionInfo(),
+    "c5501_HausZooZirkustiere_Emissionen": EmissionInfo(
+        comment="new junk Cat, group with other category?",
+    ),
+    "c5601_Feuerwerke_Emissionen": EmissionInfo(
+        comment="new junk Cat, group with other category?",
+    ),
+    "c5701_Tabakwaren_Emissionen": EmissionInfo(),
+    "c5801_BrandFeuerschaeden_Emissionen": EmissionInfo(
+        comment="new junk Cat, group with other category?",
+    ),
+    "c6101_Waelder_Emissionen": EmissionInfo(),
+    "c6201_Grasflaechen_Emissionen": EmissionInfo(),
+    "c6301_Gewaesser_Emissionen": EmissionInfo(),
+    "c6401_Blitze_Emissionen": EmissionInfo(
+        comment="new junk Cat, group with other category?",
+    ),
+}
+
+ZURICH_SOURCES_Kanton = {
     "c1101_Linienschiffe_Emissionen_Kanton": EmissionInfo(height=1.5, width=5.0),
     "c1102_PrivaterBootsverkehr_Emissionen_Kanton": EmissionInfo(height=0.5),
     "c1201_BahnPersonenverkehr_Emissionen_Kanton": EmissionInfo(height=0.3, width=3.0),
@@ -98,4 +204,119 @@ ZURICH_SOURCES = {
     "c6401_Blitze_Emissionen_Kanton": EmissionInfo(
         comment="new junk Cat, group with other category?",
     ),
+}
+
+ZURICH_DUCKDB_SOURCES = {
+    "linienschiff": EmissionInfo(height=1.5, width=5.0),
+    "privater_bootsverkehr": EmissionInfo(height=0.5),
+    "bahnpersonen": EmissionInfo(height=0.3, width=3.0),
+    "bahngüter": EmissionInfo(height=0.3, width=3.0),
+    "tram": EmissionInfo(height=0.3, width=2.0),
+#    "kleinbahnen": EmissionInfo(height=0.3, width=2.0),
+    "personenwagen": LARGE_ROAD_TRANSPORT,
+    "lastwagen": LARGE_ROAD_TRANSPORT,
+    "motorräder": LARGE_ROAD_TRANSPORT,
+    "linienbus": LARGE_ROAD_TRANSPORT,
+    "trolleybus": LARGE_ROAD_TRANSPORT,
+    "startstoptankatmung": EmissionInfo(height=0.3),
+    "lieferwagen": LARGE_ROAD_TRANSPORT,
+    "reisebus": LARGE_ROAD_TRANSPORT,
+    "ölheizung": EmissionInfo(height=3.0),
+    "gasheizung": EmissionInfo(height=3.0),
+    "holzheizung_lokalisiert": EmissionInfo(height=3.0),
+    "holzheizung_dispers": EmissionInfo(height=3.0),
+    "warmwassererzeuger": EmissionInfo(height=3.0),
+    "bhkw": EmissionInfo(height=3.0),
+    "khkw": EmissionInfo(),
+#    "KHKWErdgas": EmissionInfo(),
+#    "KHKWHeizoel": EmissionInfo(),
+    "klärschlammverwertung": EmissionInfo(),
+    "abwasserreinigung": EmissionInfo(),
+    "hochbaustelle": EmissionInfo(),
+    "bitumen": EmissionInfo(),
+    "farben_baustelle": EmissionInfo(),
+    "tiefbaustelle": EmissionInfo(),
+    "strassenbelagsarbeiten": EmissionInfo(),
+    "notstromanlage": EmissionInfo(height=3.0),
+    "prozessenergie": EmissionInfo(height=3.0),
+    "gewerbebetriebe": EmissionInfo(),
+#    "metallreinigung": EmissionInfo(),
+#    "holzbearbeitung": EmissionInfo(),
+#    "malereien": EmissionInfo(),
+#    "textilreinigung": EmissionInfo(),
+#    "karosserien": EmissionInfo(),
+#    "raeuchereien": EmissionInfo(height=3.0),
+#    "roestereien": EmissionInfo(height=3.0),
+#    "druckereien": EmissionInfo(),
+#    "laboratorien": EmissionInfo(),
+#    "bierbrauereien": EmissionInfo(),
+#    "brotproduktion": EmissionInfo(),
+#    "medizinischepraxen": EmissionInfo(),
+#    "gesundheitswesen": EmissionInfo(),
+    "krematorium": EmissionInfo(),
+#    "kompostierung": EmissionInfo(),
+    "tankstelle": EmissionInfo(),
+    "lösemittel_IG": EmissionInfo(),
+    "vergärwerk": EmissionInfo(),
+    "industrie_fahrzeug": EmissionInfo(),
+    "forst_fahrzeug": EmissionInfo(width=7.0),
+    "landwirtschaft_fahrzeug": EmissionInfo(),
+    "nutzfläche": EmissionInfo(),
+    "nutztierhaltung": EmissionInfo(),
+    "lösemittel_HH": EmissionInfo(),
+    "grünabfallverbrennung": EmissionInfo(),
+    "holzofen_kleingarten": EmissionInfo(),
+    "abfallverbrennung_haus": EmissionInfo(),
+    "haus_zoo_zirkustiere": EmissionInfo(),
+    "feuerwerk": EmissionInfo(),
+    "tabakwaren": EmissionInfo(),
+    "brandfeuerschaden": EmissionInfo(),
+    "wald": EmissionInfo(),
+    "gras": EmissionInfo(),
+    "gewässer": EmissionInfo(),
+    "blitz": EmissionInfo(),
+}
+
+# CH emissions are area sources except for eipro and eipkv
+CH_EMISSIONS = EmissionInfo(height=0.3)
+ZURICH_CH_SOURCES = {
+    'evsfa': CH_EMISSIONS,
+    'evsee': CH_EMISSIONS,
+    'ehhaf': CH_EMISSIONS,
+    'evfgva': CH_EMISSIONS,
+    'evsch': CH_EMISSIONS,
+    'ehfho': CH_EMISSIONS,
+    'evsrh': CH_EMISSIONS,
+    'eibau': CH_EMISSIONS,
+    'eilpf': CH_EMISSIONS,
+    'elfer': CH_EMISSIONS,
+    'eifrz': CH_EMISSIONS,
+    'evzon': CH_EMISSIONS,
+    'ehhab': CH_EMISSIONS,
+    'eilmi': CH_EMISSIONS,
+    'evfzrh': CH_EMISSIONS,
+    'eidep': CH_EMISSIONS,
+    'ehfoe': CH_EMISSIONS,
+    'elfeu': CH_EMISSIONS,
+    'eipkv': EmissionInfo(height=3.0),
+    'eikmp': CH_EMISSIONS,
+    'elabf': CH_EMISSIONS,
+    'eipdh': CH_EMISSIONS,
+    'evsra': CH_EMISSIONS,
+    'eipro': EmissionInfo(height=3.0),
+    'evstrf1': CH_EMISSIONS,
+    'evstrf4': CH_EMISSIONS,
+    'ehgws': CH_EMISSIONS,
+    'evstrf2': CH_EMISSIONS,
+    'eipis': CH_EMISSIONS,
+    'elver': CH_EMISSIONS,
+    'evstrf3': CH_EMISSIONS,
+    'ehare': CH_EMISSIONS,
+    'eikla': CH_EMISSIONS,
+    'ellwm': CH_EMISSIONS,
+    'eiprd': CH_EMISSIONS,
+    'elfwm': CH_EMISSIONS,
+    'ehhan': CH_EMISSIONS,
+    'ehmgh': CH_EMISSIONS,
+    'eivgn': CH_EMISSIONS,
 }

--- a/emiproc/inventories/zurich/duck.py
+++ b/emiproc/inventories/zurich/duck.py
@@ -26,6 +26,7 @@ def _parse_duckdb_table_name(
     year: int,
     geometry_column: str = "geom",
     year_column: str = "jahr",
+    substances: list[str] | None = None,
 ) -> gpd.GeoDataFrame:
     """Parse the duck db table to a GeoDataFrame."""
     columns = con.execute(f"PRAGMA table_info('{table_name}');").fetchall()
@@ -69,6 +70,16 @@ def _parse_duckdb_table_name(
         logger.debug(f"After fixing invalid geometries: {geometry.loc[mask_invalid]}")
 
     emission_columns = [col for col in columns if col.startswith("emission_")]
+    if substances is not None:
+        requested_columns = {f"emission_{substance}" for substance in substances}
+        emission_columns = [
+            col for col in emission_columns if col in requested_columns
+        ]
+        if not emission_columns:
+            raise ValueError(
+                f"None of the requested substances {substances} are available "
+                f"in table '{table_name}'."
+            )
 
     query_emissions = f"SELECT {', '.join(emission_columns)} FROM {table_name} WHERE {year_column} = {year};"
     df_emissions = con.execute(query_emissions).fetchdf()
@@ -95,6 +106,7 @@ class DuckDBInventory(Inventory):
     :param duckdb_filepath: Path to the duckDB file.
     :param year: Year of the emissions to load.
     :param skip_suffixes: List of suffixes to skip when loading tables.
+    :param substances: List of substances to load. If None, load all substances.
 
     """
 
@@ -103,6 +115,7 @@ class DuckDBInventory(Inventory):
         duckdb_filepath: PathLike,
         year: int,
         skip_suffixes: list[str] = ["_ef", "_p"],
+        substances: list[str] | None = None,
     ) -> None:
 
         if duckdb is None:
@@ -138,7 +151,9 @@ class DuckDBInventory(Inventory):
                     self.logger.debug(f"Skipping table {table} due to suffix filter.")
                     continue
                 try:
-                    gdf = _parse_duckdb_table_name(table, con, year=year)
+                    gdf = _parse_duckdb_table_name(
+                        table, con, year=year, substances=substances
+                    )
                     self.gdfs[table] = gdf
                 except Exception as e:
                     self.logger.warning(f"Skipping table {table}: {e}")
@@ -147,7 +162,6 @@ class DuckDBInventory(Inventory):
             f"DuckDBInventory initialized from {duckdb_filepath!s}. "
             f"Available tables: {available_tables}"
         )
-
         if len(self.gdfs) == 0:
             raise ValueError(
                 f"No valid tables loaded from {duckdb_filepath!s} for year {year}."
@@ -163,8 +177,8 @@ if __name__ == "__main__":
 
     # Example usage
     duckdb_file = "/home/coli/Data/zurich/Emissionskataster/emikat.db"
-    inv = DuckDBInventory(duckdb_file, year=2024)
-
+    inv = DuckDBInventory(duckdb_file, year=2024, substances=["CO2"])
+    
     inv.logger.info(f"Inventory initialized: {inv.name}")
 
     inv.logger.info(

--- a/emiproc/inventories/zurich/gral_groups.py
+++ b/emiproc/inventories/zurich/gral_groups.py
@@ -1,12 +1,126 @@
 # Cateogies taken from the Bericht CO2_GRAMM_GRAL_Bericht_UGZ_20230207
 # Any change is written there as comment
 # Categories not having any CO2 are then not included
-# There are 4 categories that have been ignored
-# 'c5801_BrandFeuerschaeden_Emissionen_Kanton'
-# 'c3418_Vergaerwerk_Emissionen_Kanton'
-# 'c5601_Feuerwerke_Emissionen_Kanton'
-# 'c5701_Tabakwaren_Emissionen_Kanton'
+# There are 3 categories that have been ignored 
+# (previously also c3418_Vergaerwerk_Emissionen was ignored)
+# 'c5801_BrandFeuerschaeden_Emissionen'
+# 'c5601_Feuerwerke_Emissionen'
+# 'c5701_Tabakwaren_Emissionen'
+# Other groups commented out do not contribute to CO2 emissions
 ZH_CO2_Groups = {
+    # Shipping
+    "Schiffahrt": [
+        "c1101_Linienschiffe_Emissionen",
+        "c1102_PrivaterBootsverkehr_Emissionen",
+    ],
+    # Industry
+    "Industrie": [
+        "c3201_Notstromanlagen_Emissionen",
+        "c3301_Prozessenergie_Emissionen",
+        # "c3401_Metallreinigung_Emissionen", # not in bericht
+        # "c3402_Holzbearbeitung_Emissionen", # not in bericht
+        # "c3403_Malereien_Emissionen", # not in bericht
+        # "c3404_Textilreinigung_Emissionen", # not in bericht
+        # "c3405_Karosserien_Emissionen", # not in bericht
+        # "c3406_Raeuchereien_Emissionen", # not in bericht
+        # "c3407_Roestereien_Emissionen", # not in bericht
+        # "c3408_Druckereien_Emissionen", # not in bericht
+        # "c3409_Laboratorien_Emissionen", # not in bericht
+        "c3410_Bierbrauereien_Emissionen",
+        "c3411_Brotproduktion_Emissionen",
+        # "c3412_MedizinischePraxen_Emissionen", # not in bericht
+        # "c3413_Gesundheitswesen_Emissionen", # not in bericht
+        "c3414_Krematorium_Emissionen",
+        "c3416_Tankstellen_Emissionen",
+    ],
+    # Fossil heating
+    "FeuerungenFossil": [
+        "c2101_Oelheizungen_Emissionen",
+        "c2102_Gasheizungen_Emissionen",
+        "c2105_Warmwassererzeuger_Emissionen",
+        "c2201_BHKW_Emissionen",
+    ],
+    # Heating
+    "Feuerungen": [
+        "c2103_HolzheizungenLokalisiert_Emissionen",
+        "c2104_HolzheizungenDispers_Emissionen",
+        "c2401_Klaerschlammverwertung_Emissionen",
+    ],
+    # Heating Power Plants
+    "KehrichtheizkraftwerkeKHKW": [
+        "c2301_KHKWKehricht_Emissionen",
+        "c2302_KHKWErdgas_Emissionen",
+        "c2303_KHKWHeizoel_Emissionen",
+    ],
+    # # Solvents and product use
+    # "GNFR_E": [
+    #     "c3417_LoesemittelIG_Emissionen",
+    #     "c5101_LoesemittelHH_Emissionen",
+    # ],
+    # Road transport
+    "Strassenverkehr": [
+        "c1301_Personenwagen_Emissionen",
+        "c1303_Motorraeder_Emissionen",
+        "c1306_StartStopTankatmung_Emissionen",
+        "c1307_Lieferwagen_Emissionen",
+    ],
+    # Heavy transport
+    "Schwerverkehr": [
+        "c1302_Lastwagen_Emissionen",
+        "c1308_Reisebusse_Emissionen",
+    ],
+    # Public transport
+    "OffentlicherVerkehr ": [
+        "c1304_Linienbusse_Emissionen",
+        # "c1305_Trolleybusse_Emissionen", # This is assumed from the bericht
+    ],
+    # Offroad mobility
+    # "GNFR_I": [
+    #    "c1201_BahnPersonenverkehr_Emissionen",
+    #    "c1202_BahnGueterverkehr_Emissionen",
+    #    "c1203_Tramverkehr_Emissionen",
+    #    "c1204_Kleinbahnen_Emissionen",
+    #    # c31xx are construction stuff
+    #    "c3102_Bitumen_Emissionen",
+    #    "c3103_FarbenBaustelle_Emissionen",
+    #    "c3105_Strassenbelag_Emissionen",
+    # ],
+    "FahrzeugeMaschinen": [
+        "c3101_MaschinenHochbau_Emissionen",
+        "c3104_MaschinenTiefbau_Emissionen",
+        "c3419_IndustrielleFZ_Emissionen",
+        "c4101_ForstwirtschaftlicheFZ_Emissionen",
+        "c4201_LandwirtschaftlicheFZ_Emissionen",
+    ],
+    # Waste
+    "Umschwung": [
+        "c5201_Gruenabfallverbrennung_Emissionen",
+        "c5301_HolzoefenKleingarten_Emissionen",
+        "c5401_AbfallverbrennungHaus_Emissionen",
+        "c3418_Vergaerwerk_Emissionen",
+    ],
+    # # AgriLivestock
+    # "GNFR_K": [
+    #     "c4401_Nutztierhaltung_Emissionen",
+    # ],
+    # # AgriOther
+    # "GNFR_L": [
+    #     "c4301_Nutzflaechen_Emissionen",
+    # ],
+    # # Others
+    # "GNFR_R": [
+    #     "c5501_HausZooZirkustiere_Emissionen",
+    #     "c5601_Feuerwerke_Emissionen",
+    #     "c5701_Tabakwaren_Emissionen",
+    #     "c5801_BrandFeuerschaeden_Emissionen",
+    #     "c6101_Waelder_Emissionen",
+    #     "c6201_Grasflaechen_Emissionen",
+    #     "c6301_Gewaesser_Emissionen",
+    #     "c6401_Blitze_Emissionen",
+    # ],
+}
+
+ZH_CO2_Groups_Kanton = {
     # Shipping
     "Schiffahrt": [
         "c1101_Linienschiffe_Emissionen_Kanton",
@@ -62,11 +176,11 @@ ZH_CO2_Groups = {
         "c1303_Motorraeder_Emissionen_Kanton",
         "c1306_StartStopTankatmung_Emissionen_Kanton",
         "c1307_Lieferwagen_Emissionen_Kanton",
-        "c1308_Reisebusse_Emissionen_Kanton",
     ],
     # Heavy transport
     "Schwerverkehr": [
         "c1302_Lastwagen_Emissionen_Kanton",
+        "c1308_Reisebusse_Emissionen_Kanton",
     ],
     # Public transport
     "OffentlicherVerkehr ": [
@@ -119,18 +233,185 @@ ZH_CO2_Groups = {
     # ],
 }
 
+ZH_CO2_DUCK_Groups = {
+    # Waste heating power plant (Hagenholz)
+    "KHKW": [
+        "khkw",
+    ],
+    # Industry
+    "Industrie": [
+        "notstromanlage",
+        "prozessenergie",
+        "gewerbebetriebe",
+#        "tankstelle",
+    ],
+    # Fossil Heating
+    "FeuerungenFossil": [
+        "ölheizung",
+        "gasheizung",
+        "warmwassererzeuger",
+        "bhkw",
+    ],
+    # Non-fossil Heating
+    "FeuerungenBio": [
+        "holzheizung_lokalisiert",
+        "holzheizung_dispers",
+    ],
+#    "GNFR_D": [
+#        "netzverluste",
+#    ],
+#    "Loesemittel": [
+#        "lösemittel_IG",
+#        "lösemittel_HH",
+#    ],
+    # Road traffic (car, light-duty, motorcycles)
+    "Strassenverkehr": [
+        "personenwagen",
+        "motorräder",
+        "startstoptankatmung",
+        "lieferwagen",
+    ],
+    # Heavy duty traffic
+    "Schwerverkehr": [
+        "lastwagen",
+        "reisebus",
+    ],
+    "OeffentlicherVerkehr": [
+        "linienbus",
+#        "trolleybus",
+    ],
+    "Schiffahrt": [
+        "linienschiff",
+        "privater_bootsverkehr",
+    ],
+    # Offroad mobility
+    # "GNFR_I": [
+    #    "bahnpersonen",
+    #    "bahngüter",
+    #    "tram",
+    #    "bitumen",
+    #    "farben_baustelle",
+    #    "strassenbelagsarbeiten",
+    # ],
+    "FahrzeugeMaschinen": [
+        "hochbaustelle",
+        "tiefbaustelle",
+        "industrie_fahrzeug",
+        "forst_fahrzeug",
+        "landwirtschaft_fahrzeug",
+    ],
+    # Waste
+    "Umschwung": [
+        "abwasserreinigung",
+        "klärschlammverwertung",
+        "vergärwerk",
+        "krematorium",
+        "grünabfallverbrennung",
+        "holzofen_kleingarten",
+        "abfallverbrennung_haus",
+    ],
+#   # AgriLivestock
+#    "GNFR_K": [
+#        "nutztierhaltung",
+#    ],
+#    # AgriOther
+#    "GNFR_L": [
+#        "nutzfläche",
+#    ],
+#    # Others
+#    "GNFR_R": [
+#        "haus_zoo_zirkustiere",
+#        "feuerwerk",
+#        "tabakwaren",
+#        "brandfeuerschaden",
+#        "wald",
+#        "gras",
+#        "gewässer",
+#        "blitz",
+#    ],
+}
+
+# Swiss invenotry is also used to be remapped on the the boundaries around Zurich
+# Note missing CO2 categories: many have been removeved becaue not in the ZH area
+# eipwp # Industrial point sources
+# eipzm # Zement Werke
+# evsrh # Rhein ships, not in zh but still
+# eipis # pisten fahrzeuge
+# elfer # landwirtschaftliche Nutzflächen
+# ehhab # Hausalte Brande
+# ehhaf # Haushalte andere Feuerwerk etc
+CH_CO2_Groups = {
+    # Feuerungen/Haushalte Fossil
+    "FeuerungenFossil_CH": [
+        "ehare",
+        "ehfoe",
+        "ehgws",
+    ],
+    # Other stationary combustion (services, residential, agriculture)
+    "FeuerungenBio_CH": [
+        "ehfho",
+    ],
+    # Road transport
+    "Verkehr_CH": [
+        "evstrf1",  # Passenger cars
+        "evstrf2",  # light duty
+        "evstrf3",  # Heavy duty
+        "evstrf4",  # motorcycles
+        "evzon",    # zone traffic, cold start/evaporation
+        "evsee",    # shipping lakes
+        "evsfa",  # Schiffahrtslininen
+#        "evsrh",    # shipping rivers
+    ],
+    # Industry and rest
+    "Rest_CH": [
+        "ehhan",  # Haushalte andere private
+        "ehmgh",  # Maschinen Garten und Hobby 
+        "eibau",  # Baumaschinen
+        "eifrz",  # Industriefahrzeuge
+        "eilmi",  # Lösungsmittel Industrie
+        "eilpf",  # Dienstleistungen Landschaftspflege 
+        "eiprd",  # Dienstleistungen Öl und Gas
+        "eipkv",  # Waste energy/heat plants (point sources)
+        "evsch",  # Schienenverkehr Bau-/Dienstzüge 
+        "evfzrh", # Flughafen Zurich
+        "ellwm",  # landwirtschaftliche Maschinen 
+        "elfwm",  # forstwirtschaftliche Maschinen
+        "eivgn",  # Verluste Gasnetz
+        "eipro",  # Flächenquellen Industrie
+        "evsra",  # Schienenverkehr Rangieren
+        "ehhab",  # Haushalte andere Brände
+        "eikmp",  # Kompostierung
+        "eipdh",  # Diensleistungen Holz und Kohle
+        "ehhaf",  # Haushalte andere feuerwerk
+        "elver",  # Vergärung
+        "eidep",  # Deponien
+        "eipis",  # Pistenfahrzeuge
+        "evsrh",  # Rhein ships
+        "eikla",  # Kläranlagen
+        "elabf",  # Abfallverbrennung Land- und Forstwirtschaft
+        "evfgva", # Geneva airport
+        "elfer",
+        "elfeu",       
+#        "eipwp",  # this is the weitere punktquelle (additional point sources)
+#        "eipzm",  # Punktquellen Zementwerke (point sources cement plants)
+#        "elapp",
+#        "elsto",
+#        "enwal",  # Emissionen aus Waldern (emissions from forests)
+    ],
+}
+
 # Swiss invenotry is also used to be remapped on the the boundaries around zuirch
 # Note missing co2 categories: many have been removeved becaue not in the zh area
 # eipwp # Industrial point sources
 # eipzm # Zement Werke
 # evsfa # Shiffarts lilinen should be verkeher
-# evsrh # Rehin shiffarts, not in zh but still
+# evsrh # Rhein ships, not in zh but still
 # eipis # pisten fahrzeuge
 # evsra # Schienenverkehr Rangieren
 # elfer # landwirtschaftliche Nutzflächen
 # ehhab # Hausalte Brande
 # ehhaf # Haushalte andere Feuerwerk etc
-CH_2_GNFR = {
+CH_2_GRAL = {
     # Road transport
     "Verkehr": [
         # "evstr_ch4",

--- a/scripts/zh_ch_co2_2_gral.py
+++ b/scripts/zh_ch_co2_2_gral.py
@@ -1,0 +1,280 @@
+"""Prepare Zurich city CO2 inventory for GRAL
+
+The script combines the following inventories:
+- MapLuft Zurich inventory (the City's inventory)
+- Swiss inventory (from the Swiss Federal Office for the Environment)
+- Human respiration inventory (from the Quartieranalyse data)
+
+and writes it out to GRAL format with point, line and area sources grouped
+by source groups according to Ivo Suter's UGZ report.
+
+The GRAL grid definition is read from a GRAL rundir using the pygg package, 
+which is specified in the GRAL_GRID variable.
+"""
+# %%
+# autoreload modules in interactive python
+%load_ext autoreload
+%autoreload 2
+# %%
+
+from pathlib import Path
+import logging
+from typing import cast
+
+import geopandas as gpd
+from shapely.geometry import Polygon
+
+from emiproc.exports.gral import export_to_gral
+from emiproc.grids import LV95, WGS84
+from emiproc.inventories.swiss import SwissRasters
+from emiproc.inventories.utils import (
+    add_inventories,
+    crop_with_shape,
+    clip_box,
+    group_categories,
+    validate_group,
+    drop,
+)
+from emiproc.human_respiration import (
+    load_data_from_quartieranalyse,
+    people_to_emissions,
+    EmissionFactor,
+)
+from emiproc.inventories.zurich import MapLuftZurich
+from emiproc.inventories.zurich.gral_groups \
+    import ZH_CO2_Groups, ZH_CO2_DUCK_Groups, CH_CO2_Groups
+
+#from emiproc.regrid import remap_inventory
+from emiproc.speciation import merge_substances
+from emiproc.utilities import Units
+from emiproc.inventories.zurich.duck import DuckDBInventory
+from pygg.grids import GralGrid
+
+# %% define some parameters for the output
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+# define year for which to generate emissions
+YEAR = 2024
+
+# Whether to include the Swiss inventory outside of Zurich in the output
+INCLUDE_SWISS_OUTSIDE = True
+
+# Whether to add the human respiration
+ADD_HUMAN_RESPIRATION = True
+
+# Substances to include (so far only CO2)
+substances = ["CO2"]
+
+# Paths to data
+emis_dir = Path("/cluster/home/dbrunner/data/emissions")
+swiss_dir = emis_dir / "bafu"
+out_dir = emis_dir / "exports"
+mapluft_dir = emis_dir / "mapluft"  
+duckdbs_dir = emis_dir / "mapluft" / "duckdbs"
+
+# Choose here which data file to use
+# Duck db is the new version, it contains multiple years in one file
+# (our current version only 2023 and 2024)
+#inv_file = mapluft_dir / f"mapLuft_{YEAR}_v2024.gdb"
+inv_file = duckdbs_dir / f"emikat_v2026a.db"
+
+# GRAL grid to which inventory is exported
+gral_dir = Path("/cluster/scratch/dbrunner/gg_run_dir/GRAL_00001")
+GRAL_GRID = GralGrid.from_gral_rundir(gral_dir)
+
+# CRS of the output, can be WGS84 or LV95
+OUTPUT_CRS = GRAL_GRID.crs
+
+# Edge of the raster cells (in meters) for our GRAL raster
+RASTER_DX = GRAL_GRID.dx
+RASTER_DY = GRAL_GRID.dy
+
+VERSION = "v3.2"
+
+# File with the data required for the human respiration
+quartier_anlyse_dir = emis_dir / "quartieranalyse" / "v202605"
+quartier_anlyse_file = quartier_anlyse_dir / "Quartieranalyse_-OGD.gpkg"
+
+# the following is the unit of the output, should be kg/h
+output_unit = Units.KG_PER_HOUR
+
+# %% Check some parameters and create the output directory
+weights_dir = out_dir / f"weights_files_gralgrid_{RASTER_DX}_{RASTER_DY}_{YEAR}_{VERSION}_crs{OUTPUT_CRS}"
+weights_dir.mkdir(exist_ok=True, parents=True)
+
+# %% load the zurich inventory
+if inv_file.suffix == ".gdb":
+    inv_zh = MapLuftZurich(inv_file,substances=substances)
+
+    ignore_categories = ['c5801_BrandFeuerschaeden_Emissionen',
+                         'c5601_Feuerwerke_Emissionen',
+                         'c5701_Tabakwaren_Emissionen']
+
+else:
+    # for duckdb, we need to provide the substances in lower case, 
+    # as they are stored in lower case in the database
+    inv_zh = DuckDBInventory(inv_file, year=YEAR,
+                            substances=[str(sub).lower() for sub in substances])
+
+    ignore_categories = ['brandfeuerschaden',
+                         'feuerwerk',
+                         'tabakwaren']
+
+    ZH_CO2_Groups = ZH_CO2_DUCK_Groups
+
+# remove the ignore categories from the inventory
+inv_zh = drop(inv_zh,categories=ignore_categories)
+
+# check if all categories except for ignore_categories are matched with ZH_CO2_Group
+#check_categories = [category for category in inv.categories 
+#                    if category not in ignore_categories]
+
+validate_group(ZH_CO2_Groups, inv_zh.categories)
+
+
+# %% add the swiss inventory outside Zurich
+
+def load_zurich_shape(
+    zh_raw_file= emis_dir / "Zurich_borders.txt",
+    crs_file: int = WGS84,
+    crs_out: int = LV95,
+) -> Polygon:
+    with open(zh_raw_file, "r") as f:
+        points_list = eval(f.read())
+        zh_poly = Polygon(points_list[0])
+        zh_poly_df = gpd.GeoDataFrame(geometry=[zh_poly], crs=crs_file).to_crs(crs_out)
+        zh_poly = zh_poly_df.geometry.iloc[0]
+        return zh_poly
+
+
+swiss_dir = emis_dir / "bafu"
+# The csv file contains the total emissions for all categories and substances,
+# used to calculate the scaling factors for the Swiss inventory outside of zurich
+# The file was generated with Corina's script dict_process_grid.py in a version that
+# allows splitting traffic into 4 subcategories (f1: cars, f2: light duty, f3: heavy duty, f4: two wheels)
+filepath_csv_totals = swiss_dir / "CH_emissions_2020_2022_2024_CO2.csv"
+inv_ch = SwissRasters(
+    filepath_csv_totals=filepath_csv_totals,
+    filepath_point_sources=swiss_dir / "swissprtr-daten-2007-2024.xlsx",
+    rasters_dir=swiss_dir / "ekat_gridascii",
+    rasters_str_dir=swiss_dir / "ekat_str_gridascii",
+    requires_grid=True,
+    year=YEAR,
+    substances=["CO2", "CO2_biog"],
+)
+# crop inventory to GRAL domain to speed-up subsequent processing
+inv_ch = clip_box(inv_ch, GRAL_GRID.xmin, GRAL_GRID.ymin, 
+                  GRAL_GRID.xmax, GRAL_GRID.ymax)
+
+print('CH inventory successfully loaded')
+
+# since we do not differentiate between biogenic and anthropogenic CO2
+# at this stage, we merge the biogenic and fossi contributions
+#merge_substances(inv_ch, {"CO2_bio": ["CO2_biog"]}, inplace=True)
+#merge_substances(inv_ch, {"CO2_fos": ["CO2"]}, inplace=True)
+
+merge_substances(inv_ch, {"CO2": ["CO2", "CO2_biog"]}, inplace=True)
+
+# check whether all required groups are available and apply grouping
+validate_group(CH_CO2_Groups, inv_ch.categories)
+
+ch_outside_zh = crop_with_shape(
+    inv_ch,
+    load_zurich_shape(),
+    keep_outside=True,
+    modify_grid=False,
+    #weight_file=weights_dir / "ch_out_zh",
+)
+
+# add the scaled Swiss inventory to the Zurich inventory
+inv_combined = add_inventories(inv_zh, ch_outside_zh)
+
+# %% Add the human respiration
+if ADD_HUMAN_RESPIRATION:
+
+    # Load the data. It is available for the whole canton of Zurich,
+    # which covers the whole grid of the output
+    df_quartier = load_data_from_quartieranalyse(quartier_anlyse_file,
+                                                 GRAL_GRID)
+
+    # Load into an emiproc Inventory
+    raw_resp_inv = people_to_emissions(
+        df_quartier,
+        # Assumes people spend 60% of their time at home and 40% at work
+        time_ratios={"people_living": 0.6, "people_working": 0.4},
+        emission_factor={
+            ("people_living", "CO2"): EmissionFactor.ROUGH_ESTIMATON,
+            ("people_working", "CO2"): EmissionFactor.ROUGH_ESTIMATON
+        },
+    )
+
+    # Group the categories
+    resp_inv = raw_resp_inv.copy()
+    resp_inv = group_categories(
+            resp_inv,
+            {
+                "AtmungZuhause": ["people_living"], 
+                "AtmungArbeit": ["people_working"],
+            },
+        )
+    
+    # We may crop human respiration to the zurich shape but we don't
+    # resp_inv = crop_with_shape(resp_inv, load_zurich_shape())
+
+    #resp_inv = gdf_to_gdfs(resp_inv)
+
+    #inv_combined = add_inventories(inv_combined, resp_inv)
+
+# %% check point
+from emiproc.inventories.zurich.categories_info import ZURICH_DUCKDB_SOURCES, ZURICH_CH_SOURCES
+
+# combined
+ZH_COMBINED_SOURCES = {**ZURICH_DUCKDB_SOURCES, **ZURICH_CH_SOURCES}
+ZH_RESP= {"AtmungZuhause": ["AtmungZuhause"], 
+        "AtmungArbeit": ["AtmungArbeit"]}
+ZH_COMBINED_GROUPS = {**ZH_CO2_DUCK_Groups, **CH_CO2_Groups, **ZH_RESP}
+
+def add_sg_info(cat_info, cat_groups):
+
+    # source group numbers according to UGZ report
+    source_groups = {
+        "KHKW": 14,
+        "Industrie": 15,
+        "FeuerungenFossil": 11,
+        "FeuerungenBio": 12,
+        "Strassenverkehr": 6,
+        "Schwerverkehr": 7,
+        "OeffentlicherVerkehr": 9,
+        "Schiffahrt": 1,
+        "FahrzeugeMaschinen": 17,
+        "Umschwung": 18,
+        "FeuerungenFossil_CH": 35,
+        "FeuerungenBio_CH": 36,
+        "Verkehr_CH": 34,
+        "Rest_CH": 37,
+        "AtmungZuhause": 61,
+        "AtmungArbeit": 62,
+    }
+
+    new_cat = {}
+
+    for cat in cat_info:
+        for grp, members in cat_groups.items():
+            if cat in members:
+                new_cat[cat] = cat_info[cat]
+                new_cat[cat].source_group = source_groups[grp]
+                break
+
+    return new_cat
+
+inv_zh.emission_infos = add_sg_info(ZH_COMBINED_SOURCES,ZH_COMBINED_GROUPS)
+
+# %%
+
+export_to_gral(
+    inv_zh,
+    GRAL_GRID,
+    out_dir / 'test'
+)
+# %%


### PR DESCRIPTION
Changes in this branch compared to master:

- new script zh_ch_co2_2_gral.py for generation of GRAL emission files for Zurich
- Zurich inventory swiss.py: added option to load only data for substances of interest
- Zurich inventory duck.py: added option to load only data for substances of interest
- Export gral.py: source_group information is now taken from EmissionInfo and not generated automatically.  Furthermore, the polygon_raster_size information is taken from the GralGrid rather than provided as input to the gral export.
- Inventories __init__.py: class EmissionInfo extended with additional parameter source_group

See script zh_ch_co2_2_gral.py for an example how the source_group information can be added to the EmissionsInfo before exporting to GRAL.


<!-- readthedocs-preview emiproc start -->
----
📚 Documentation preview 📚: https://emiproc--149.org.readthedocs.build/en/149/

<!-- readthedocs-preview emiproc end -->