### PR TITLE
Fix CI stucked

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,7 +32,7 @@ jobs:
         black --check ./tests
     - name: Install package
       run: |
-        python -m pip install pytest matplotlib h5netcdf[h5py]
+        python -m pip install pytest pytest-timeout matplotlib h5netcdf[h5py]
         python -m pip install -e .
     - name: Test with pytest
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,10 @@ testpaths = ["tests"]
 markers = [
     "incremental: mark a test as part of an incremental test suite"
 ]
+# Dump a thread traceback and fail instead of hanging forever (helps diagnose
+# intermittent CI hangs). Requires the pytest-timeout plugin.
+timeout = 360
+timeout_method = "thread"
 
 [tool.setuptools.packages.find]
 include = ["emiproc"]  # package names should match these glob patterns (["*"] by default)
@@ -71,4 +75,4 @@ doc = [
     "ipython",
     "matplotlib",
 ]
-dev = ["black", "pytest"]
+dev = ["black", "pytest", "pytest-timeout"]


### PR DESCRIPTION
Sometimes the ci was stucked during the tests. 

this attempt to see where it is stucked exaclty by adding a timeout to pytest

<!-- readthedocs-preview emiproc start -->
----
📚 Documentation preview 📚: https://emiproc--155.org.readthedocs.build/en/155/

<!-- readthedocs-preview emiproc end -->